### PR TITLE
Fix for Issue#35: updated voice/set to match voiceSystem payload.

### DIFF
--- a/conformance.py
+++ b/conformance.py
@@ -119,7 +119,7 @@ CONFORMANCE_TEST_CASE = [
     ("app-telemetry/stop",f'{{"appId": "{config.apps["youtube"]}"}}', dab.app_telemetry.stop, 200, "Conformance"),
     ("health-check/get",'{}', dab.health_check.get, 2000, "Conformance"),
     ("voice/list",'{}', dab.voice.list, 200, "Conformance"),
-    ("voice/set",f'{{"voiceSystem": {config.va}}}', dab.voice.set, 5000, "Conformance"),
+    ("voice/set",f'{{"voiceSystem":{{"name":"{config.va}","enabled":true}}}}', dab.voice.set, 5000, "Conformance"),
     ("voice/send-audio",'{"fileLocation": "https://storage.googleapis.com/ytlr-cert.appspot.com/voice/ladygaga.wav"}',dab.voice.send_audio, 10000, "Conformance"),
     ("voice/send-text",'{"requestText" : "Play lady Gaga music on YouTube", "voiceSystem": "Alexa"}', dab.voice.send_text, 10000, "Conformance"),
     ("version",' {}', dab.version.default, 200, "Conformance"),


### PR DESCRIPTION
**Why this change is needed:**
Added missing key & values to match voiceSystem in the voice/set request as per https://github.com/device-automation-bus/dab-specification-2.0/blob/main/DAB.md#operation-setting-enabled-voice-systems in compliance suite.
```
$ python3 main.py -v -b <IP> -I <DeviceID> -c VoiceSetConformance

testing voice/set   {"voiceSystem":{"name":"AmazonAlexa","enabled":true}} ... 

voice/set Latency, Expected: 5000 ms, Actual: 235 ms

[ PASS ]

{
  "status": 200,
  "voiceSystem": {
    "enabled": true,
    "name": "AmazonAlexa"
  }
}
```