### PR TITLE
Add initial Netflix test cases

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,13 +19,15 @@ import end_to_end_cobalt
 import voice_audio
 import voice_text
 import output_image
+import netflix
 
 ALL_SUITES = {
     "conformance": conformance.CONFORMANCE_TEST_CASE,
     "end_to_end_cobalt": end_to_end_cobalt.END_TO_END_TEST_CASE,
     "voice_audio": voice_audio.SEND_VOICE_AUDIO_TEST_CASES,
     "voice_text": voice_text.SEND_VOICE_TEXT_TEST_CASES,
-    "output_image": output_image.OUTPUT_IMAGE_TEST_CASES
+    "output_image": output_image.OUTPUT_IMAGE_TEST_CASES,
+    "netflix": netflix.NETFLIX_TEST_CASES
 }
 
 if __name__ == "__main__":

--- a/netflix.py
+++ b/netflix.py
@@ -1,0 +1,45 @@
+import dab.applications
+import dab.input
+import config
+
+# The user must be logged into Netflix to perform the Play Movie test
+NETFLIX_TEST_CASES = [
+# This is your RDK UI shell, replace callsign if different
+#    ("applications/exit", f'{{"appId": "GravityApp", "background": true}}', dab.applications.exit, 10000, "GravityApp Suspend"),
+
+    ("applications/launch",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.launch, 20000, "Netflix Launch"),
+    ("applications/get-state",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.get_state, 200, "Netflix After Launch"),
+
+#Wait until Netflix shows the user menu before answering test result
+    ("input/key-press",'{"keyCode": "KEY_ENTER"}', dab.input.key_press, 1000, "Netflix KEY_ENTER 1"),
+
+    ("applications/exit", f'{{"appId": "{config.apps["netflix"]}", "background": true}}', dab.applications.exit, 5000, "Netflix Suspend"),
+    ("applications/get-state",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.get_state, 200, "Netflix After Suspend"),
+
+    ("applications/exit",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.exit, 5000, "Netflix Stop"),
+    ("applications/get-state",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.get_state, 200, "Netflix After Stop"),
+
+    ("applications/launch",f'{{"appId": "{config.apps["netflix"]}","parameters": ["m=80092839"]}}', dab.applications.launch, 20000, "Netflix Play Movie"),
+
+#Wait until Netflix shows the play menu before answering test result
+    ("input/key-press",'{"keyCode": "KEY_ENTER"}', dab.input.key_press, 1000, "Netflix KEY_ENTER 2"),
+
+    ("applications/get-state",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.get_state, 200, "Netflix After Play Movie"),
+
+    ("applications/exit",f'{{"appId": "{config.apps["netflix"]}"}}', dab.applications.exit, 5000, "Netflix Stop Again"),
+
+#  The current dab-adapter-rs Media Keys do not work with Netflix. Use those keys with "/opt/dab_platform_keymap.json":
+
+#{
+#    "RDKSHELL_KEY_PAUSE":19,
+#    "RDKSHELL_KEY_PLAY":226,
+#    "RDKSHELL_KEY_HOMEPAGE":409
+#}
+
+#    ("input/key-press",'{"keyCode": "RDKSHELL_KEY_PAUSE"}', dab.input.key_press, 1000, "RDKSHELL_KEY_PAUSE"),
+#    ("input/key-press",'{"keyCode": "RDKSHELL_KEY_PLAY"}', dab.input.key_press, 1000, "RDKSHELL_KEY_PLAY"),
+#    ("input/key-press",'{"keyCode": "RDKSHELL_KEY_HOMEPAGE"}', dab.input.key_press, 1000, "RDKSHELL_KEY_HOMEPAGE"),
+
+# This is your RDK UI shell, replace callsign if different
+#    ("applications/launch", f'{{"appId": "GravityApp"}}', dab.applications.launch, 10000, "GravityApp Launch"),
+]


### PR DESCRIPTION
Hello @bgy36ww and @denisyuji,

This PR complements the changes made for Netflix support by @arun-madhavan-013 and me in [dab-adapter-rs](https://github.com/device-automation-bus/dab-adapter-rs).

I placed some comments inside "netflix.py" but I think we need the way to display some instructions while performing the test cases. Please let me know if I need to change something otherwise kindly approve the code.

Thank you!