### PR TITLE
'audioVolume' is not handled correctly by is_setting_supported

### DIFF
--- a/util/enforcement_manager.py
+++ b/util/enforcement_manager.py
@@ -1,5 +1,5 @@
 from singleton_decorator import singleton
-from typing import List
+from typing import List, Dict
 
 class Resolution:
     width: int
@@ -76,6 +76,15 @@ class EnforcementManager:
         if isinstance(self.supported_settings.get(setting), bool) and self.supported_settings.get(setting):
             return True
     
+        if (
+               setting == 'audioVolume' and
+               isinstance(self.supported_settings.get(setting), Dict) and
+               any('min' in d for d in self.supported_settings.get(setting)) and
+               any('max' in d for d in self.supported_settings.get(setting)) and
+               self.supported_settings.get(setting)['min'] != self.supported_settings.get(setting)['max']
+           ):
+            return True
+
     def add_supported_application(self, application):
         self.supported_applications.add(application)
 


### PR DESCRIPTION
The 'audioVolume' setting has a very specific definition in the DAB specification, for system/settings/list, unlike the other settings who are either lists/arrays or booleans. 'audioVolume' is defined as a dictionary, with 2 elements 'min' and 'max'. Moreover, the volume control is considered disabled if 'min' and 'max' have the same value. Currently, is_setting_supported() doesn't handle 'audioVolume' correctly, because it can handle only lists or booleans. So a specific handling for 'audioVolume' is added, to match the DAB specification.