### PR TITLE
is_setting_supported() shall not return True for every Dict to comply with the DAB2.0 specification

### DIFF
--- a/util/enforcement_manager.py
+++ b/util/enforcement_manager.py
@@ -73,9 +73,6 @@ class EnforcementManager:
         if isinstance(self.supported_settings.get(setting), List) and self.supported_settings.get(setting):
             return True
 
-        if isinstance(self.supported_settings.get(setting), Dict) and self.supported_settings.get(setting):
-            return True
-
         if isinstance(self.supported_settings.get(setting), bool) and self.supported_settings.get(setting):
             return True
     


### PR DESCRIPTION
is_setting_supported() shall not return True for every Dict, since the rules for enabling the Dict as per the DAB2.0 specification are more complex.
The merge of a faulty PR ended up having is_setting_supported() return True for every Dict that is non empty, which is totally in contradiction with the DAB 2.0 specification.
First of all, there is only 1 Dict currently in the DAB 2.0 certification, it's audioVolume. And the rules for enabling this setting are very specific, and already defined in a later PR also merged, which checks whether 'min' and 'max' are both defined, and have different values. But right now, for audioVolume, it will check if it's a non-empty Dict, and return True if it is, regardless of 'min'/'max' and their respective value, which is wrong.
So we must remove the faulty lines...