### PR TITLE
fix voice/list add_supported_voice_assistant operation

### DIFF
--- a/conformance.py
+++ b/conformance.py
@@ -120,9 +120,9 @@ CONFORMANCE_TEST_CASE = [
     ("app-telemetry/stop",f'{{"appId": "{config.apps["youtube"]}"}}', dab.app_telemetry.stop, 200, "Conformance"),
     ("health-check/get",'{}', dab.health_check.get, 2000, "Conformance"),
     ("voice/list",'{}', dab.voice.list, 200, "Conformance"),
-    ("voice/set",f'{{"voiceSystem":{{"name":"{EnforcementManager().get_voice_assistant()}","enabled":true}}}}', dab.voice.set, 5000, "Conformance"),
-    ("voice/send-audio",f'{{"fileLocation": "https://storage.googleapis.com/ytlr-cert.appspot.com/voice/ladygaga.wav", "voiceSystem": "{EnforcementManager().get_voice_assistant()}"}}',dab.voice.send_audio, 10000, "Conformance"),
-    ("voice/send-text",f'{{"requestText" : "Play lady Gaga music on YouTube", "voiceSystem": "{EnforcementManager().get_voice_assistant()}"}}', dab.voice.send_text, 10000, "Conformance With VA"),
+    ("voice/set",f'{{"voiceSystem":{{"name":"{config.va}","enabled":true}}}}', dab.voice.set, 5000, "Conformance"),
+    ("voice/send-audio",f'{{"fileLocation": "https://storage.googleapis.com/ytlr-cert.appspot.com/voice/ladygaga.wav", "voiceSystem": "{config.va}"}}',dab.voice.send_audio, 10000, "Conformance"),
+    ("voice/send-text",f'{{"requestText" : "Play lady Gaga music on YouTube", "voiceSystem": "{config.va}"}}', dab.voice.send_text, 10000, "Conformance With VA"),
     ("version",' {}', dab.version.default, 200, "Conformance"),
     ("system/restart",' {}', dab.system.restart, 30000, "Conformance"),
 ]

--- a/dab/voice.py
+++ b/dab/voice.py
@@ -43,7 +43,10 @@ def list(test_result, durationInMs=0,expectedLatencyMs=0):
     response  = jsons.loads(test_result.response)
     if response['status'] != 200:
         return False
-    EnforcementManager().add_supported_voice_assistant(response.voiceSystems)
+    for voiceSystem in response['voiceSystems']:
+        print("current ", voiceSystem)
+        if voiceSystem['enabled'] is True:
+            EnforcementManager().add_supported_voice_assistant(voiceSystem['name'])
     sleep(0.1)
     return Default_Validations(test_result, durationInMs, expectedLatencyMs)
 


### PR DESCRIPTION
voice/list :
the device is response as example https://github.com/device-automation-bus/dab-specification-2.0/blob/main/DAB.md#sample-response-10 .
{
   "status": 200,
   "voiceSystems": [
      {
         "name": "AmazonAlexa",
         "enabled": true
      },
      {
         "name": "GoogleAssistant",
         "enabled": false
      },
      {
         "name": "Siri",
         "enabled": false
      }
   ]
}
But the test suit report an error when receive this response.
testing voice/list   {} ... [ FAILED ]
AttributeError raised during result validation:
'dict' object has no attribute 'voiceSystems'

{
  "status": 200,
  "voiceSystems": [
    {
      "name": "WhaleAIVoice",
      "enabled": true
    }
  ]
}