### PR TITLE
Reason for change: Updating response message for system/restart conformance test

### DIFF
--- a/dab/system.py
+++ b/dab/system.py
@@ -15,7 +15,7 @@ def restart(test_result, durationInMs=0,expectedLatencyMs=0):
         return False
     print("restarting...wait 60s...",end='',flush=True)
     sleep(60)
-    return YesNoQuestion(test_result, "Cobalt re-started?")
+    return YesNoQuestion(test_result, "Device re-started?")
 
 def get(test_result, durationInMs=0,expectedLatencyMs=0):
     try:


### PR DESCRIPTION
system/restart conformance test which is supposed to restart the device in showing wrong confirmation message to the user
Currently it is:

```
sam2@sam2-VirtualBox:~/dab/dab-compliance-suite$ python3 main.py -v -b 192.168.0.238 -I 02AD20D40151 -c SystemRestartConformance
testing system/restart    {} ... restarting...wait 60s...Cobalt re-started?(Y/N)
```
It should be
```
sam2@sam2-VirtualBox:~/dab/dab-compliance-suite$ python3 main.py -v -b 192.168.0.238 -I 02AD20D40151 -c SystemRestartConformance
testing system/restart    {} ... restarting...wait 60s...Device re-started?(Y/N)
```
Test Procedure: build and verify

Risks: low

PR for #58 issue