### PR TITLE
Add an optional test case parameter for a manual preparation

### DIFF
--- a/dab_tester.py
+++ b/dab_tester.py
@@ -20,9 +20,12 @@ class DabTester:
             return 1
     
     def Execute_Test_Case(self, device_id, test_case):
-        (dab_request_topic, dab_request_body, validate_output_function, expected_response, test_title)=test_case
+        (dab_request_topic, dab_request_body, validate_output_function, expected_response, test_title, *opt)=test_case
         test_result = TestResult(to_test_id(f"{dab_request_topic}/{test_title}"), device_id, dab_request_topic, dab_request_body, "UNKNOWN", "", [])
         print("\ntesting", dab_request_topic, " ", dab_request_body, "... ", end='', flush=True)
+        # Optionally prompt tester if a manual preparation is required.
+        if opt:
+            input(opt[0] + ", press ENTER when ready.")
         start = datetime.datetime.now()
         code = self.execute_cmd(device_id, dab_request_topic, dab_request_body)
         test_result.response = self.dab_client.response()


### PR DESCRIPTION
In some cases a manual preparation from the tester might be necessary before running a certain test case. I propose adding an optional sixth parameter to the test case tuple. It'll contain a short description of the preparation steps necessary for the tester and halt execution of the test until the tester presses the enter key. Since the parameter is optional, this change is backwards compatible for all the existing test suites.