### PR TITLE
Feature/test result enhancements

### DIFF
--- a/.github/workflows/update-test-version.yml
+++ b/.github/workflows/update-test-version.yml
@@ -1,0 +1,41 @@
+name: Update Test Version on Main Push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Generate 8-digit Test Version
+        run: |
+          DATE=$(date +'%y%m%d')
+          VERSION_FILE="test_version.txt"
+          if [ -f "$VERSION_FILE" ]; then
+            LAST_VERSION=$(cat $VERSION_FILE)
+            LAST_DATE=${LAST_VERSION:0:6}
+            LAST_COUNT=${LAST_VERSION:6:2}
+            if [ "$LAST_DATE" = "$DATE" ]; then
+              COUNT=$(printf "%02d" $((10#$LAST_COUNT + 1)))
+              VERSION="${DATE}${COUNT}"
+            else
+              VERSION="${DATE}01"
+            fi
+          else
+            VERSION="${DATE}01"
+          fi
+          echo $VERSION > $VERSION_FILE
+
+      - name: Commit & Push Test Version
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add test_version.txt
+          git commit -m "chore: update test version to $(cat test_version.txt)" || echo "No changes to commit"
+          git push
+

--- a/dab_tester.py
+++ b/dab_tester.py
@@ -6,6 +6,10 @@ from readchar import readchar
 from re import split
 import datetime
 import jsons
+from result_json import TestSuite
+import datetime
+import os
+
 
 class DabTester:
     def __init__(self,broker):
@@ -71,6 +75,26 @@ class DabTester:
         file_dump = jsons.dumps(result_list, indent = 4)
         with open(test_result_output_path, "w") as outfile:
                 outfile.write(file_dump)
+
+    def Execute_Single_Test(self, suite_name, device_id, test_case, test_result_output_path):
+        result_list = TestSuite([], suite_name)
+        if not isinstance(test_case, tuple) or len(test_case) < 5:
+            raise ValueError("Invalid test_case structure. Expected tuple with 5 elements.")
+        result_list.test_result_list.append(self.Execute_Test_Case(device_id, test_case))
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        if not test_result_output_path or os.path.isdir(test_result_output_path):
+            output_dir = test_result_output_path if test_result_output_path else "./test_result"
+            os.makedirs(output_dir, exist_ok=True)
+            test_result_output_path = os.path.join(output_dir, f"{suite_name}_single_{timestamp}.json")
+        else:
+            os.makedirs(os.path.dirname(test_result_output_path), exist_ok=True)
+        try:
+            file_dump = jsons.dumps(result_list, indent=4)
+            with open(test_result_output_path, "w") as outfile:
+               outfile.write(file_dump)
+        except Exception as e:
+            print(f"[ERROR] Failed to write test result to {test_result_output_path}: {e}")
+            raise
 
 
     def Close(self):

--- a/main.py
+++ b/main.py
@@ -102,5 +102,5 @@ if __name__ == "__main__":
                 for test_case in suite_to_run[suite]:
                     (dab_request_topic, dab_request_body, validate_output_function, expected_response, test_title) = test_case
                     if (to_test_id(f"{dab_request_topic}/{test_title}") == args.case):
-                        Tester.Execute_Test_Case(device_id,(test_case))
+                        Tester.Execute_Single_Test(suite, device_id, test_case, args.output)
     Tester.Close()


### PR DESCRIPTION
Enhance single test execution to auto-generate timestamped result JSON
------------
This commit introduces the ability to automatically generate uniquely named test result files for single test executions by including a timestamp in the filename.

Output path now includes timestamp for easy tracking (e.g., suite_name_single_20240527_145501.json)

If a directory is passed as output path, the system ensures it exists and appends a timestamped file

Prevents accidental overwriting of previous results

How Was This Tested?
--------
Executed with:
python3 main.py -v -b 127.0.0.1 -I device2 -c "SystemSettingsSetCec" -o ./test_result/
Confirmed that the result JSON file was created with the expected format and content.

Affected Files --> dab_tester.py
_____________________________________________

Add GitHub Action to auto-generate 8-digit test version on main push
--------------------
This commit introduces a GitHub Actions workflow that automatically generates a new 8-digit test version string every time a push is made to the main branch. The version string is saved to test_version.txt.

Version format: YYYYMMDD + 2-digit counter (e.g., 2024052701)

Ensures every build has a unique and traceable version ID

test_version.txt can be read during test runs and injected into result JSON

Workflow File
.github/workflows/update-test-version.yml