### PR TITLE
feat: support --bridge-version override in bridge version detection

### DIFF
--- a/dab_tester.py
+++ b/dab_tester.py
@@ -12,13 +12,13 @@ import os
 from util.enforcement_manager import ValidateCode
 
 class DabTester:
-    def __init__(self,broker):
+    def __init__(self,broker, override_bridge_version=None):
         self.dab_client = DabClient()
         self.dab_client.connect(broker,1883)
         self.dab_checker = DabChecker(self)
         self.verbose = False
         self.bridge_version = None  # Will be set by auto-detect logic
-
+        self.override_bridge_version = override_bridge_version
         # Load valid DAB topics using jsons
         try:
             with open("valid_dab_topics.json", "r", encoding="utf-8") as f:
@@ -339,7 +339,12 @@ class DabTester:
         """
         Detects DAB bridge version by calling 'dab/version' once.
         Stores version string in self.bridge_version.
+        Honors override_bridge_version if explicitly provided.
         """
+        if hasattr(self, 'override_bridge_version') and self.override_bridge_version:
+            self.bridge_version = self.override_bridge_version
+            print(f"[INFO] Forced DAB bridge version (override): {self.bridge_version}")
+            return
         try:
             # Send request manually (not via test case)
             self.dab_client.request(device_id, "version", "{}")

--- a/main.py
+++ b/main.py
@@ -65,6 +65,12 @@ if __name__ == "__main__":
     parser.add_argument("-s","--suite",
                         help="set what test suite to run. Available test suite includes:" + test_suites_str,
                         type=str)
+    
+    parser.add_argument("--bridge-version",
+                        help="Override detected DAB bridge version. Use 2.0 or 2.1 to force specific test compatibility.",
+                        type=str,
+                        choices=["2.0", "2.1"],
+                        default=None)
 
     parser.set_defaults(output="")
     
@@ -74,7 +80,7 @@ if __name__ == "__main__":
     # Use the DabTester
     device_id = args.ID
 
-    Tester = DabTester(args.broker)
+    Tester = DabTester(args.broker, override_bridge_version=args.bridge_version)
     
     Tester.verbose = args.verbose
 


### PR DESCRIPTION
- Added support for manually overriding detected bridge version via CLI flag (--bridge-version)
- If override is passed, the detect_bridge_version() method uses it directly
- Ensures backward compatibility by falling back to auto-detection logic when no override is provided