### PR TITLE
Feat/preflight discovery healthcheck

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,120 @@
+# logger.py
+from dataclasses import dataclass
+from datetime import datetime
+import os, sys
+
+# ---------- ANSI ----------
+RESET = "\x1b[0m"
+BOLD  = "\x1b[1m"
+DIM   = "\x1b[2m"
+ITAL  = "\x1b[3m"
+
+FG_RED     = "\x1b[31m"
+FG_GREEN   = "\x1b[32m"
+FG_YELLOW  = "\x1b[33m"
+FG_BLUE    = "\x1b[34m"
+FG_MAGENTA = "\x1b[35m"
+FG_CYAN    = "\x1b[36m"
+FG_WHITE   = "\x1b[37m"
+FG_GRAY    = "\x1b[90m"  # light gray
+FG_BWHITE  = "\x1b[97m"  # bright white
+
+def _now_ms() -> str:
+    return datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+
+def _supports_color() -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    try:
+        return sys.stdout.isatty()
+    except Exception:
+        return False
+
+@dataclass
+class RunLogger:
+    """
+    - [INFO]/[OK]/[WAIT] only when verbose=True (dim, italic, light gray, slightly brighter)
+    - [WARN]/[ERROR]/[RESULT]/[FATAL]/[PROMPT] always (bold/bright)
+    - Brighter light-gray timestamp with ms on every line
+    - Skips blank lines so you won’t see: “[INFO]  ”
+    """
+    verbose: bool = False
+    enable_color: bool = True
+
+    # ---------- styling ----------
+    def _style_ts(self, ts: str) -> str:
+        if not self.enable_color or not _supports_color():
+            return ts
+        # brighter light gray: bright white + dim
+        return f"{DIM}{FG_BWHITE}{ts}{RESET}"
+
+    def _style_msg(self, level: str, msg: str, always: bool) -> str:
+        if not self.enable_color or not _supports_color():
+            return msg
+        if not always:
+            # verbose-only lines: “smaller” but a bit brighter 
+            return f"{DIM}{ITAL}{FG_BWHITE}  · {msg}{RESET}"
+        # always-on lines: brighter/bolder
+        if level == "WARN":
+            return f"{BOLD}{FG_YELLOW}{msg}{RESET}"
+        if level == "ERROR":
+            return f"{BOLD}{FG_RED}{msg}{RESET}"
+        if level == "FATAL":
+            return f"{BOLD}{FG_RED}{msg}{RESET}"
+        if level == "PROMPT":
+            return f"{BOLD}{FG_MAGENTA}{msg}{RESET}"
+        if level == "RESULT":
+            return f"{BOLD}{FG_BWHITE}{msg}{RESET}"
+        if level == "OK":
+            return f"{BOLD}{FG_GREEN}{msg}{RESET}"
+        return f"{BOLD}{msg}{RESET}"
+
+    # ---------- core ----------
+    def _emit(self, level: str, msg: str, always: bool = False):
+        # skip empty/whitespace-only lines → prevents “[INFO]  ”
+        if msg is None or str(msg).strip() == "":
+            return
+        if always or self.verbose:
+            ts = self._style_ts(_now_ms())
+            styled = self._style_msg(level, str(msg), always)
+            print(f"{ts} [{level}] {styled}")
+
+    # levels
+    def info(self, msg: str):   self._emit("INFO", msg, always=False)
+    def ok(self, msg: str):     self._emit("OK", msg, always=False)
+    def wait(self, msg: str):   self._emit("INFO", msg, always=False)  # keep label for compatibility
+    def warn(self, msg: str):   self._emit("WARN", msg, always=True)
+    def error(self, msg: str):  self._emit("ERROR", msg, always=True)
+    def fatal(self, msg: str):  self._emit("FATAL", msg, always=True)
+    def result(self, msg: str): self._emit("RESULT", msg, always=True)
+    def prompt(self, msg: str): self._emit("PROMPT", msg, always=True)
+
+    # plain stamped line for persisted logs (no ANSI)
+    def stamp(self, line: str) -> str:
+        return f"{_now_ms()} {line}"
+
+    # optional helpers
+    def test_start(self, name: str, test_id: str, topic: str, device: str, request_body: str, suite: str | None = None):
+        bar = "═" * 79
+        sep = "─" * 79
+        self.result(bar)
+        self.result(f"Starting test: {name}")
+        self.result(f"Test ID: {test_id}")
+        if suite:
+            self.result(f"Suite: {suite}")
+        self.result(f"Topic: {topic}")
+        self.result(f"Device: {device}")
+        self.result(f"Request body: {request_body}")
+        self.result(sep)
+
+    def test_end(self, outcome: str, duration_ms: int | None = None):
+        sep = "─" * 79
+        self.result(sep)
+        if duration_ms is not None:
+            self.result(f"Result: {outcome} · Total wall time: {duration_ms} ms")
+        else:
+            self.result(f"Result: {outcome}")
+        self.result("═" * 79)
+
+# Shared singleton
+LOGGER = RunLogger(verbose=False, enable_color=True)

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ import conformance
 import output_image
 import netflix
 import functional
+from logger import LOGGER 
 
 ALL_SUITES = {
     "conformance": conformance.CONFORMANCE_TEST_CASE,
@@ -72,41 +73,51 @@ if __name__ == "__main__":
     
     parser.set_defaults(case=99999)
     args = parser.parse_args()
-    
-    # Use the DabTester
+    LOGGER.verbose = bool(args.verbose)
     device_id = args.ID
 
     Tester = DabTester(args.broker, override_dab_version=args.dab_version)
     
     Tester.verbose = args.verbose
+    try:
+        Tester.logger.verbose = Tester.verbose 
+    except Exception:
+        pass
+    LOGGER.info(f"Starting run with broker {args.broker}, device ID '{device_id}', suite='{args.suite or 'ALL'}', output='{args.output or '(default)'}', dab-version override='{args.dab_version or 'auto'}'.")
 
     suite_to_run = {}
 
     if (args.suite):
         # Let dict throw KeyError here
         suite_to_run.update({args.suite: ALL_SUITES[args.suite]})
+        LOGGER.info(f"Selected suite: '{args.suite}' with {len(suite_to_run[args.suite])} tests.")
     else:
         suite_to_run = ALL_SUITES
-
+        LOGGER.info(f"No suite specified. All suites selected: {', '.join(suite_to_run.keys())}.")
 
     if(args.list == True):
         for suite in suite_to_run:
+            LOGGER.info(f"Listing test cases for suite '{suite}'...")
             for test_case in suite_to_run[suite]:
                 (dab_request_topic, dab_request_body, validate_output_function, expected_response, test_title, test_version, is_negative) = Tester.unpack_test_case(test_case)
                 if dab_request_topic is None:
                     continue
-                print(to_test_id(f"{dab_request_topic}/{test_title}"))
+                LOGGER.result(to_test_id(f"{dab_request_topic}/{test_title}"))
     else:
         if ((not isinstance(args.case, (str)) or len(args.case) == 0)):
-            # Test all the cases
-            print("Testing all cases")
+            LOGGER.result("Testing all cases")
             for suite in suite_to_run:
+                LOGGER.info(f"Preparing to run suite '{suite}' with {len(suite_to_run[suite])} tests.")
+                Tester.assert_device_available(device_id)
                 Tester.Execute_All_Tests(suite, device_id, suite_to_run[suite], args.output)
+                LOGGER.ok(f"Completed suite '{suite}'.")
         else:
             # Handle single or multiple cases passed via -c
             requested_cases = [c.strip() for c in args.case.split(",")]
+            LOGGER.info(f"Requested case IDs: {requested_cases}")
             matched_tests = []
             for suite in suite_to_run:
+                LOGGER.info(f"Searching for requested cases in suite '{suite}'...")
                 for test_case in suite_to_run[suite]:
                     (dab_request_topic, dab_request_body, validate_output_function, expected_response, test_title, test_version, is_negative) = Tester.unpack_test_case(test_case)
                     if dab_request_topic is None:
@@ -115,9 +126,12 @@ if __name__ == "__main__":
                     if test_id in requested_cases:
                         matched_tests.append(test_case)
                 if matched_tests:
+                    LOGGER.result(f"Matched {len(matched_tests)} case(s) in suite '{suite}'.")
+                    Tester.assert_device_available(device_id)
                     Tester.Execute_Single_Test(suite, device_id, matched_tests, args.output)
                     break
             else:
-                print(f"None of the test case(s) matched: {requested_cases}")
+                LOGGER.error(f"None of the requested test case IDs matched: {requested_cases}")
 
     Tester.Close()
+    LOGGER.ok("Run complete. Connection closed.")


### PR DESCRIPTION
# PR Title
Add Preflight Discovery + Health-Check Before Tests

---

## Why

- Prevent tests from running when the target device is offline or unhealthy.
- Make test failures clearer and reduce flaky behavior.

---

## What Changed

### Discovery API
- **`DabClient.discover_devices()`**:
  - Publishes to `dab/discovery`.
  - Listens on a unique reply topic.
  - Returns a list of `deviceId` + IP mappings.

---

### Preflight Steps

1. **Discovery Check**
   - Verify that the target device is present.
   - If not found, mark all tests as `SKIPPED` with a message listing available devices (if any).

2. **Health Check**
   - Call `dab/<device>/health-check/get` with retries.
   - If it fails, prompt user with options:
     - **Retry**
     - **Continue**
     - **Terminate**

---

## Where It’s Used

### Conformance Suite
- `Execute(...)` runs the preflight check before sending any test request.

### Functional Suite
- One-time **discovery upfront**:
  - If the device is not found → mark tests as `SKIPPED` and exit.
- **Per-test health-check** (same as conformance):
  - If health check fails and user chooses "terminate" → current + remaining tests are marked as `SKIPPED` with reason.

---

## Modified Files

- `dab_client.py`: added `discover_devices(...)`
- `dab_tester.py`: added
  - `PreflightTermination` exception
  - `_preflight_discovery_or_raise(...)`
  - `pretest_health_check(...)`
  - Integrated discovery + health-check into conformance and functional flows

---

## Behavior Summary

- Discovery fails → mark all tests as `SKIPPED` with a reason and available device list (if any)
- Health check fails → prompt user with options
  - "Terminate" skips remaining tests with explanation

---

## Follow-ups (Future PRs
[console.log](https://github.com/user-attachments/files/21817801/console.log)
)

- Standardize logging under shared `LOGGER` styling
- Add CLI flag for **non-interactive runs** (CI environments)
- Make discovery timeout and retry count configurable
