### PR TITLE
Feat/new tests functional

### DIFF
--- a/conformance.py
+++ b/conformance.py
@@ -185,13 +185,12 @@ CONFORMANCE_TEST_CASE = [
     ("voice/send-text",f'{{"requestText" : "Play lady Gaga music on YouTube", "voiceSystem": true}}', dab.voice.send_text, 10000, "Conformance With VA Bad Request5", "2.0", True),
     ("version",' {}', dab.version.default, 200, "Conformance", "2.0", False),
     ("system/restart",' {}', dab.system.restart, 30000, "Conformance", "2.0", False),
-    ("applications/install", lambda: json.dumps({"fileLocation": f"file://{ensure_app_available()}"}), dab.applications.install, 120000, "Install App Conformance", "2.1", False), 
+    ("applications/install", lambda: json.dumps(ensure_app_available(app_id="Sample_App")), dab.applications.install, 120000, "Install App Conformance", "2.1", False),
     ("applications/install", lambda: json.dumps({"fileLocation": f""}), dab.applications.install, 120000, "Install App Conformance With Blank URL", "2.1", True),
     ("applications/install", lambda: json.dumps({"fileLocation": f"file://{ensure_app_available('unsupported_format_app.txt')}"}), dab.applications.install, 120000, "Install App Conformance With Incorrect Format", "2.1", True),
-
     ("applications/uninstall",lambda: f'{{"appId": "{config.apps["sample_app"]}"}}', dab.applications.uninstall, 50000, "Conformance", "2.1", False),
     ("applications/uninstall",lambda: f'{{"appId": "com.example!@#"}}', dab.applications.uninstall, 50000, "Conformance Bad Request", "2.1", True),
-    ("applications/clear-data",lambda: f'{{"app_url": "{config.apps["sample_app_url"]}"}}', dab.applications.clear_data, 10000, "Conformance", "2.1", False),
+    ("applications/clear-data",lambda: f'{{"appId": "{config.apps["youtube"]}"}}', dab.applications.clear_data, 10000, "Conformance", "2.1", False),
     ("applications/clear-data",lambda: f'{{"appId": ""}}', dab.applications.clear_data, 10000, "Conformance Bad Request", "2.1", True),
     ("applications/install-from-app-store", lambda: json.dumps({"appId": get_or_prompt_appstore_url()}), dab.applications.install_from_appstore, 120000, "Install App Conformance", "2.1" , False),
     ("system/logs/start-collection", '{}', dab.system.start_log_collection, 200, "Conformance", "2.1" , False), 
@@ -204,5 +203,5 @@ CONFORMANCE_TEST_CASE = [
     ("system/power-mode/get", '{}', dab.system.power_mode_get, 200, "Conformance", "2.1" , False),
     ("system/power-mode/set", '{"powerMode": "Standby"}', dab.system.power_mode_set, 200, "Conformance", "2.1" , False),
     ("system/power-mode/set", '{"powerMode": "invalid"}', dab.system.power_mode_set, 200, "Conformance Bad Request", "2.1" , True),
-    ("system/setup/skip", '{}', dab.system.setup_skip, 1000, "Conformance", "2.1" , False),
+    ("system/setup/skip", '{}', dab.system.setup_skip, 1000, "Conformance", "2.1" , False),    
 ]


### PR DESCRIPTION
"feat(functional): add & register install/uninstall/clear-data tests; tighten logging & gating" -m "
### What’s new
- Added 13 functional tests for DAB application lifecycle:
  1) ClearDataUserInstalledAppForeground
  2) InstallFromAppStoreAndLaunch
  3) InstallYouTubeKidsFromStore
  4) UninstallPreinstalledAppAfterStandby
  5) InstallBackgroundAndUninstallSampleApp
  6) UninstallSampleAppWithLocalData_NoList
  7) UninstallPreinstalledWithLocalData_Simple
  8) InstallFromUrlDuringIdleThenLaunch
  9) InstallLargeApkFromUrlThenLaunch
  10) InstallFromUrlWhileHeavyAppRunning
  11) InstallAfterRebootThenLaunch (uses fire_and_forget_restart)
  12) SequentialInstallsFromUrlsThenLaunch
  13) InstallFromUrlThenLaunch_Simple

### Implementation notes
- All tests use \`need(...)\` for capability gating (OPTIONAL_FAILED on missing ops).
- Status evaluation based on DAB \`status==200\` only (no 202/409 branches).
- Minimal steps, single \`msg\` variable per log, no \`applications/list\` unless explicitly needed.
- Reboot test uses \`fire_and_forget_restart\` helper (no ad-hoc reboot topics).
- \`ensure_app_available()\` returns ready-to-send payload {appId, url, format, timeout}.