### PR TITLE
Use LOGGER for image handling, metrics, and error messages

### DIFF
--- a/dab/output.py
+++ b/dab/output.py
@@ -3,6 +3,7 @@ from schema import dab_response_validator
 from time import sleep
 from dab_tester import YesNoQuestion, Default_Validations
 from util.output_image_handler import save_output_image
+from logger import LOGGER  # ← add this import
 import jsons, os
 
 def image(test_result, durationInMs=0, expectedLatencyMs=0):
@@ -10,27 +11,22 @@ def image(test_result, durationInMs=0, expectedLatencyMs=0):
     try:
         dab_response_validator.validate_output_image_response_schema(test_result.response)
     except Exception as error:
-        print("Schema error:", error)
+        LOGGER.warn(f"Schema error: {error}")
         return False
 
     # 2) Parse response
     try:
         response = jsons.loads(test_result.response) if isinstance(test_result.response, str) else test_result.response
     except Exception as e:
-        print("Schema error: Could not parse JSON:", e)
+        LOGGER.warn(f"Schema error: Could not parse JSON: {e}")
         return False
 
     if not isinstance(response, dict) or response.get('status') != 200:
         return False
 
     # 3) Use the exact folder where results JSON is/will be written
-    #    (exported by write_test_result_json via DAB_RESULTS_JSON)
     env_json = os.environ.get("DAB_RESULTS_JSON")
-    if env_json:
-        results_root = os.path.dirname(env_json) or "."
-    else:
-        # fallback (kept minimal)
-        results_root = "./test_result"
+    results_root = os.path.dirname(env_json) if env_json else "./test_result"
 
     # 4) Save image BEFORE Yes/No prompt — to <results_root>/images/...
     try:
@@ -41,37 +37,24 @@ def image(test_result, durationInMs=0, expectedLatencyMs=0):
             filename_prefix=getattr(test_result, "operation", "output_image"),
         )
         setattr(test_result, "_artifact_saved", True)  # optional: avoid re-save later
-        setattr(test_result, "saved_image_path", png_path)
 
-        # record where the image is saved in logs (optional but helpful)
-        try:
-            if not hasattr(test_result, "logs") or test_result.logs is None:
-                test_result.logs = []
-            test_result.logs.append(f"[INFO] Screenshot saved: {png_path}")
-        except Exception:
-            pass
+        # console-only info (do not add to test_result.logs)
+        LOGGER.info(f"Screenshot saved: {png_path}")
 
     except Exception as e:
-        print("Image save error:", e)
+        LOGGER.warn(f"Image save error: {e}")
         return False
 
     # 5) Prompt and run default timing validation
     prompt = f"Verify '{png_path}' exists and shows the screenshot"
     ok = YesNoQuestion(test_result, prompt) and Default_Validations(test_result, durationInMs, expectedLatencyMs)
 
-    # 6) After user validation succeeds, delete the saved file (minimal change)
-    if ok:
-        try:
-            if os.path.exists(png_path):
-                os.remove(png_path)
-                try:
-                    test_result.logs.append(f"[INFO] Deleted screenshot after validation: {png_path}")
-                except Exception:
-                    pass
-        except Exception as e:
-            try:
-                test_result.logs.append(f"[WARN] Failed to delete screenshot: {e}")
-            except Exception:
-                pass
+    # 6) Always attempt to delete the saved file (even if validations failed) — console-only logs
+    try:
+        if os.path.exists(png_path):
+            os.remove(png_path)
+            LOGGER.result(f"Deleted screenshot after validation: {png_path}")
+    except Exception as e:
+        LOGGER.warn(f"Failed to delete screenshot: {e}")
 
     return ok

--- a/dab_client.py
+++ b/dab_client.py
@@ -5,6 +5,7 @@ from paho.mqtt.packettypes import PacketTypes
 import paho.mqtt.client as mqtt
 import json
 import uuid
+from logger import LOGGER 
 
 METRICS_TIMES = 5
 
@@ -36,7 +37,8 @@ class DabClient:
         metrics_response = json.loads(message.payload)
         if self.__metrics_count < METRICS_TIMES:
             self.__metrics_count += 1
-            print(metrics_response)
+            logger = getattr(self, "logger", LOGGER)
+            logger.info(f"{metrics_response}")
         else:
             self.__metrics_state = True
             self.__lock.release()
@@ -88,16 +90,17 @@ class DabClient:
         return self.__code
     
     def last_error_msg(self):
-        if(self.__code == -1):
-            print("Unknown error",end='')
-        elif(self.__code == 100):
-            print("Timeout",end='')
-        elif(self.__code == 400):
-            print("Request invalid or malformed",end='')
-        elif(self.__code == 500):
-            print("Internal error",end='')
-        elif(self.__code == 501):
-            print("Not implemented",end='')
+        logger = getattr(self, "logger", LOGGER)
+        if (self.__code == -1):
+            logger.warn("Unknown error")
+        elif (self.__code == 100):
+            logger.warn("Timeout")
+        elif (self.__code == 400):
+            logger.warn("Request invalid or malformed")
+        elif (self.__code == 500):
+            logger.error("Internal error")
+        elif (self.__code == 501):
+            logger.warn("Not implemented")
 
     # ---- Minimal discovery compatible with callers passing attempts + wait_seconds ----
     def discover_devices(self, attempts: int = 1, wait_seconds: float = 1.0):


### PR DESCRIPTION
* DabChecker: robust system/settings/set precheck & logging
* Require key presence; bool=false→UNSUPPORT; empty list→UNSUPPORT
* Enum mismatch & non-numeric/out-of-range values→UNCERTAIN
* Fetch & cache settings/list; structured LOGGER info lines


* Always delete screenshots; 
* stop persisting paths in results JSON Precheck 
* system/settings/set: require key; 
* log ranges/enums Gate unsupported settings as OPTIONAL_FAILED via cap check