### PR TITLE
Add reboot test

### DIFF
--- a/conformance.py
+++ b/conformance.py
@@ -181,6 +181,7 @@ CONFORMANCE_TEST_CASE = [
     ("voice/send-text",f'{{"requestText" : "Play lady Gaga music on YouTube", "voiceSystem": true}}', dab.voice.send_text, 10000, "Conformance With VA Bad Request5", "2.0", True),
     ("version",' {}', dab.version.default, 200, "Conformance", "2.0", False),
     ("system/restart",' {}', dab.system.restart, 30000, "Conformance", "2.0", False),
+    ("system/restart", ' {}', dab.system.restart_compliance, 30000, "Reboot Compliance Test", "2.0", False),    
     ("applications/install", lambda: json.dumps(ensure_app_available(app_id="Sample_App", prompt_if_missing=False)), dab.applications.install, 120000, "Install App Conformance", "2.1", False),
     ("applications/install", lambda: json.dumps({"fileLocation": f""}), dab.applications.install, 120000, "Install App Conformance With Blank URL", "2.1", True),
     ("applications/install", lambda: json.dumps(build_incorrect_format_body()), dab.applications.install, 120000, "Install App Conformance With Incorrect Format", "2.1", True),    

--- a/dab/system.py
+++ b/dab/system.py
@@ -19,6 +19,27 @@ def restart(test_result, durationInMs=0,expectedLatencyMs=0):
     LOGGER.info("system/restart issued. Device will reboot; subsequent preflight health-check will wait for readiness.")
     return YesNoQuestion(test_result, "Device re-started?")
 
+  def restart_compliance(test_result, durationInMs=0,expectedLatencyMs=0):
+      try:
+          dab_response_validator.validate_dab_response_schema(test_result.response)
+      except Exception as error:
+          print("Schema error:", error)
+          return False
+      response  = jsons.loads(test_result.response)
+      if response['status'] != 200:
+          return False
+      LOGGER.info("system/restart issued. Waiting for device to reboot and verify DAB stays enabled...")
+      sleep(10) # Wait for device to go down
+      
+      import dab_tester
+      tester = dab_tester.ACTIVE_TESTER
+      if tester:
+          # Wait up to 2 minutes (12 * 10s) for the device to be healthy again
+          return tester.pretest_health_check(test_result.device_id, retries=12, delay_sec=10, interactive=False)
+      else:
+          LOGGER.warn("DabTester instance not available for validation.")
+          return False
+
 def settings_get(test_result, durationInMs=0,expectedLatencyMs=0):
     try:
         dab_response_validator.validate_get_system_settings_response_schema(test_result.response)

--- a/dab_tester.py
+++ b/dab_tester.py
@@ -22,6 +22,7 @@ from packaging.version import Version, InvalidVersion
 DAB_VERSION = "2.0" # default dab version is 2.0, this global value will be used in system/settings/... operations.
 
 # Raised when preflight (discovery/health) decides we should stop the run.
+ACTIVE_TESTER = None
 class PreflightTermination(Exception):
     pass
 
@@ -35,6 +36,7 @@ class DabTester:
         self.override_dab_version = override_dab_version
         self.logger = LOGGER
         self.logger.verbose = self.verbose
+        global ACTIVE_TESTER; ACTIVE_TESTER = self
         # Load valid DAB topics using jsons
         try:
             with open("valid_dab_topics.json", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Some devices are not properly persisting DAB after device restart. Adding a test to test suite to confirm compliance.