### PR TITLE
fix: validate mqtt broker argument

### DIFF
--- a/dab_client.py
+++ b/dab_client.py
@@ -6,6 +6,7 @@ import paho.mqtt.client as mqtt
 import json
 import uuid
 from logger import LOGGER 
+from util.argument_validator import handle_connection_error
 
 METRICS_TIMES = 5
 
@@ -49,8 +50,11 @@ class DabClient:
         self.__client.disconnect()
 
     def connect(self,broker_address,broker_port):
-        self.__client.connect(broker_address, port=broker_port)
-        self.__client.loop_start()
+        try:
+            self.__client.connect(broker_address, port=broker_port)
+            self.__client.loop_start()
+        except Exception as e:
+            handle_connection_error(broker_address, broker_port, e)
     
     def request(self,device_id,operation,msg="{}"):
         # Send request and block until get the response or timeout

--- a/dab_tester.py
+++ b/dab_tester.py
@@ -75,6 +75,19 @@ class DabTester:
         log(tr, f"[REASON] {reason}")
         return tr
 
+    def _result_before_payload(self, outcome: str, device_id: str, topic: str, title: str, reason: str, extra_logs: list = None):
+        """Return a TestResult directly before payload resolution."""
+        test_id = to_test_id(f"{topic}/{title}")
+        tr = TestResult(test_id, device_id, topic, "{}", outcome, "", [])
+        tr.test_result = outcome
+        self.logger.warn(f"[{outcome}] {title} (test_id={test_id}) - {reason}")
+        log(tr, f"[TEST] {title} (test_id={test_id}, device={device_id})")
+        for line in extra_logs or []:
+            if line:
+                log(tr, line)
+        log(tr, f"[REASON] {reason}")
+        return tr
+
     def _resolve_body_or_skip(self, device_id: str, topic: str, title: str, body_spec):
         """
         Build the request body. If it fails, return a SKIPPED or OPTIONAL_FAILED TestResult.
@@ -88,29 +101,12 @@ class DabTester:
             return True, body_str, None
         except PayloadConfigError as e:
             reason = str(e)
-            is_app_install_topic = "applications/install" in topic
-            is_app_related_error = (
-                "app store url" in reason.lower()
-                or "install artifact" in reason.lower()
-                or "not found" in reason.lower()
-            )
-
-            # ----- START: MODIFIED LOGIC -----
-            # If the test is for app installation on a DAB 2.0 device and the payload failed
-            # because an app file/URL is missing, mark it as OPTIONAL_FAILED.
-            if self.dab_version == "2.0" and is_app_install_topic and is_app_related_error:
-                outcome = "OPTIONAL_FAILED"
-                self.logger.warn(f"[{outcome}] {test_id} — {reason} (Optional for DAB 2.0).")
-                hint = "This test is optional for DAB 2.0 devices and is skipped."
-            else:
-                # Fallback to the original behavior for all other cases.
-                outcome = "SKIPPED"
-                hint = getattr(e, "hint", "")
-                log_msg = f"[{outcome}] {test_id} — payload/config missing: {reason}."
-                if hint:
-                    log_msg += f" {hint}"
-                self.logger.warn(log_msg)
-            # ----- END: MODIFIED LOGIC -----
+            outcome = "SKIPPED"
+            hint = getattr(e, "hint", "")
+            log_msg = f"[{outcome}] {test_id} — payload/config missing: {reason}."
+            if hint:
+                log_msg += f" {hint}"
+            self.logger.warn(log_msg)
 
             tr = TestResult(test_id, device_id, topic, "{}", outcome, "", [])
             tr.test_result = outcome
@@ -416,6 +412,45 @@ class DabTester:
 
         test_id = to_test_id(f"{dab_request_topic}/{test_title}")
 
+        # Run applicability checks before resolving payloads that may have side effects.
+        if not self.dab_version:
+            self.detect_dab_version(device_id)
+
+        dab_version = self.dab_version or "2.0"
+
+        try:
+            if Version(dab_version) < Version(test_version):
+                reason = f"\033[1;33m[ OPTIONAL_FAILED - Requires DAB Version {test_version}, but device version is {dab_version} ]\033[0m"
+                return self._result_before_payload(
+                    outcome="OPTIONAL_FAILED",
+                    device_id=device_id,
+                    topic=dab_request_topic,
+                    title=test_title,
+                    reason=reason,
+                )
+        except InvalidVersion as e:
+            self.logger.warn(f"[WARNING] Version comparison failed (invalid version string): {e}")
+
+        if dab_request_topic != "operations/list":
+            validate_code, prechecker_log = self.dab_checker.is_operation_supported(
+                device_id,
+                dab_request_topic,
+            )
+            unsupported = validate_code == ValidateCode.UNSUPPORT
+            uncertain_install = dab_request_topic == "applications/install" and validate_code == ValidateCode.UNCERTAIN
+            if unsupported or uncertain_install:
+                reason = "\033[1;33m[ OPTIONAL_FAILED - Required DAB Operation is NOT SUPPORTED by this device ]\033[0m"
+                if uncertain_install:
+                    reason = "\033[1;33m[ OPTIONAL_FAILED - Required DAB Operation support could not be confirmed by this device ]\033[0m"
+                return self._result_before_payload(
+                    outcome="OPTIONAL_FAILED",
+                    device_id=device_id,
+                    topic=dab_request_topic,
+                    title=test_title,
+                    reason=reason,
+                    extra_logs=[prechecker_log],
+                )
+
         # Try to build/resolve payload. If it fails, return a SKIPPED TestResult (no test_start)
         ok, dab_request_body, skipped_tr = self._resolve_body_or_skip(device_id, dab_request_topic, test_title, body_spec)
         if not ok:
@@ -443,25 +478,6 @@ class DabTester:
 
             # Initialize result object for logging and reporting
             test_result = TestResult(to_test_id(f"{dab_request_topic}/{test_title}"), device_id, dab_request_topic, dab_request_body, "UNKNOWN", "", [])
-            # ------------------------------------------------------------------------
-            # DAB Version Compatibility Check
-            # If the test is meant for DAB 2.1 but the dav version is on DAB 2.0,
-            # treat this as OPTIONAL_FAILED instead of skipping or erroring out.
-            # This ensures transparency in test result reporting.
-            # ------------------------------------------------------------------------
-            dab_version = self.dab_version or "2.0"
-
-            # MODIFIED: Use packaging.version for robust comparison
-            try:
-                if Version(dab_version) < Version(test_version):
-                    test_result.test_result = "OPTIONAL_FAILED"
-                    log(test_result, f"\033[1;33m[ OPTIONAL_FAILED - Requires DAB Version {test_version}, but device version is {dab_version} ]\033[0m")
-                    # close section before returning
-                    total_ms = int((time.time() - section_wall_start) * 1000)
-                    self.logger.test_end(outcome=test_result.test_result, duration_ms=total_ms)
-                    return test_result
-            except InvalidVersion as e:
-                log(test_result, f"[WARNING] Version comparison failed (invalid version string): {e}")
 
             # ------------------------------------------------------------------------
             # Capability filter 
@@ -483,18 +499,6 @@ class DabTester:
             except Exception:
                 # do not alter flow on capability check errors; continue to existing checks
                 pass
-
-            # Check operation support via operations/list (prechecker)
-            if dab_request_topic != 'operations/list':
-                validate_code, prechecker_log = self.dab_checker.is_operation_supported(device_id, dab_request_topic)
-
-                if validate_code == ValidateCode.UNSUPPORT:
-                    test_result.test_result = "OPTIONAL_FAILED"
-                    log(test_result, prechecker_log)
-                    log(test_result, f"\033[1;33m[ OPTIONAL_FAILED - Requires DAB Operation is NOT SUPPORTED ]\033[0m")
-                    total_ms = int((time.time() - section_wall_start) * 1000)
-                    self.logger.test_end(outcome=test_result.test_result, duration_ms=total_ms)
-                    return test_result
 
             # ------------------------------------------------------------------------
             # If precheck is supported and this is not a negative test case

--- a/logger.py
+++ b/logger.py
@@ -45,15 +45,15 @@ class RunLogger:
     def _style_ts(self, ts: str) -> str:
         if not self.enable_color or not _supports_color():
             return ts
-        # brighter light gray: bright white + dim
-        return f"{DIM}{FG_BWHITE}{ts}{RESET}"
+        # Using only DIM dims the terminal's default text color (gray on dark, dark gray on light backgrounds)
+        return f"{DIM}{ts}{RESET}"
 
     def _style_msg(self, level: str, msg: str, always: bool) -> str:
         if not self.enable_color or not _supports_color():
             return msg
         if not always:
-            # verbose-only lines: “smaller” but a bit brighter 
-            return f"{DIM}{ITAL}{FG_BWHITE}  · {msg}{RESET}"
+            # verbose-only lines: dim and italicized
+            return f"{DIM}{ITAL}  · {msg}{RESET}"
         # always-on lines: brighter/bolder
         if level == "WARN":
             return f"{BOLD}{FG_YELLOW}{msg}{RESET}"
@@ -64,7 +64,7 @@ class RunLogger:
         if level == "PROMPT":
             return f"{BOLD}{FG_MAGENTA}{msg}{RESET}"
         if level == "RESULT":
-            return f"{BOLD}{FG_BWHITE}{msg}{RESET}"
+            return f"{BOLD}{msg}{RESET}"
         if level == "OK":
             return f"{BOLD}{FG_GREEN}{msg}{RESET}"
         return f"{BOLD}{msg}{RESET}"

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ import argparse
 from logger import LOGGER
 from util.config_loader import init_interactive_setup, make_app_id_list
 from util.runtime_config_store import load_config, apply_overrides, save_config
+from util.argument_validator import validate_arguments_and_warn
 
 config_path = os.environ.get("DAB_CONFIG_JSON")
 
@@ -42,7 +43,7 @@ if __name__ == "__main__":
                         action="store_true")
     parser.set_defaults(list=False)
     parser.add_argument("-b","--broker", 
-                        help="set the IP of the MQTT broker. Ex: -b 192.168.0.100",
+                        help="set the IP or host of the MQTT broker (host/IP only, no mqtt:// and no port). Ex: -b 192.168.0.100",
                         type=str,
                         default="localhost")
 
@@ -84,6 +85,7 @@ if __name__ == "__main__":
     parser.set_defaults(output="")
     parser.set_defaults(case=99999)
     args = parser.parse_args()
+    validate_arguments_and_warn(args)
     LOGGER.verbose = bool(args.verbose)
     device_id = args.ID
 

--- a/util/argument_validator.py
+++ b/util/argument_validator.py
@@ -1,0 +1,90 @@
+# util/argument_validator.py
+import sys
+import socket
+from logger import LOGGER
+
+def validate_broker(broker_val):
+    """
+    Validates the broker address parameter.
+    Rejects:
+      - Empty values
+      - URLs containing protocol schemes (e.g., mqtt://, mqtts://)
+      - Host with port (e.g., host:port, [ipv6]:port)
+      - Slashes or URL paths
+    """
+    if not broker_val or not broker_val.strip():
+        LOGGER.fatal("MQTT Broker argument validation failed:")
+        LOGGER.fatal(f"  Invalid value: {repr(broker_val)}")
+        LOGGER.fatal("  Mistake: The MQTT broker address cannot be empty.")
+        LOGGER.fatal("  Correct command: python3 main.py -b <host/IP> -I <device-id>")
+        LOGGER.fatal("  Note: The port 1883 is added internally.")
+        sys.exit(2)
+
+    broker_val_stripped = broker_val.strip()
+
+    # Check if it contains any scheme (like mqtt://, mqtts://, http://, etc.)
+    if "://" in broker_val_stripped:
+        LOGGER.fatal("MQTT Broker argument validation failed:")
+        LOGGER.fatal(f"  Invalid value: '{broker_val}'")
+        LOGGER.fatal("  Mistake: Do not include the protocol scheme (e.g., 'mqtt://' or 'mqtts://').")
+        LOGGER.fatal("  Correct command: python3 main.py -b <host/IP> -I <device-id>")
+        LOGGER.fatal("  Note: The port 1883 is added internally.")
+        sys.exit(2)
+
+    # Check for URL paths or trailing slashes
+    if "/" in broker_val_stripped:
+        LOGGER.fatal("MQTT Broker argument validation failed:")
+        LOGGER.fatal(f"  Invalid value: '{broker_val}'")
+        LOGGER.fatal("  Mistake: Do not include URL paths or trailing slashes.")
+        LOGGER.fatal("  Correct command: python3 main.py -b <host/IP> -I <device-id>")
+        LOGGER.fatal("  Note: The port 1883 is added internally.")
+        sys.exit(2)
+
+    # Check for host:port combination (IP-v6 compliant)
+    if ":" in broker_val_stripped:
+        num_colons = broker_val_stripped.count(":")
+        is_invalid_port = False
+        
+        if num_colons == 1:
+            # Simple host:port or IPv4:port
+            parts = broker_val_stripped.split(":")
+            if parts[1].isdigit():
+                is_invalid_port = True
+        elif num_colons > 1 and "]" in broker_val_stripped:
+            # Bracketed IPv6 with port, e.g., [::1]:1883
+            parts = broker_val_stripped.rsplit(":", 1)
+            if len(parts) == 2 and parts[1].isdigit():
+                is_invalid_port = True
+
+        if is_invalid_port:
+            LOGGER.fatal("MQTT Broker argument validation failed:")
+            LOGGER.fatal(f"  Invalid value: '{broker_val}'")
+            LOGGER.fatal("  Mistake: Do not specify a port number (e.g., ':1883').")
+            LOGGER.fatal("  Correct command: python3 main.py -b <host/IP> -I <device-id>")
+            LOGGER.fatal("  Note: The port 1883 is added internally.")
+            sys.exit(2)
+
+def validate_arguments_and_warn(args):
+    """
+    Validates command line arguments and outputs helpful warnings/hints.
+    """
+    # Validate broker
+    validate_broker(args.broker)
+
+    # Warn if using default values that might be common mistakes
+    if args.broker == "localhost":
+        LOGGER.warn("[HINT] Using default broker host 'localhost'. If your device is on a different network/host, specify it via -b.")
+
+    if args.ID == "localhost":
+        LOGGER.warn("[HINT] Using default device ID 'localhost'. If your target device has a custom ID, specify it via -I.")
+
+def handle_connection_error(broker_address, broker_port, exception):
+    """
+    Defensively handles connection-related errors.
+    Logs clean, actionable FATAL messages and exits cleanly.
+    """
+    LOGGER.fatal("MQTT Connection failed:")
+    LOGGER.fatal(f"  Broker address: {broker_address}:{broker_port}")
+    LOGGER.fatal(f"  Error: {type(exception).__name__}: {exception}")
+    LOGGER.fatal("  Please ensure that the MQTT broker is running, reachable, and the host/IP is correct.")
+    sys.exit(2)

--- a/util/config_loader.py
+++ b/util/config_loader.py
@@ -209,18 +209,6 @@ def ensure_app_available_anyext(
     found = _find_first_app_file(app_id, config_dir)
     if not found:
         if not prompt_if_missing:
-            try:
-                from util.runtime_api_server import wait_for_runtime_install_artifact
-
-                found = wait_for_runtime_install_artifact(app_id, config_dir=config_dir)
-            except Exception as e:
-                LOGGER.warn(f"[RUNTIME INSTALL] Could not prepare temporary runtime install bridge: {e}")
-
-        if found:
-            found = found.resolve()
-            return _to_install_payload(app_id, found, timeout=timeout)
-
-        if not prompt_if_missing:
             raise FileNotFoundError(
                 f"Install artifact for app_id='{app_id}' not found in '{config_dir}'. "
                 "Place it there (any extension) or run with --init."
@@ -628,7 +616,7 @@ class PayloadConfigError(Exception):
 def _hint_from_reason(reason: str) -> str:
     low = str(reason).lower()
     if "install artifact" in low or "config/apps" in low:
-        return "Place the app file in config/apps or run with --init to configure paths."
+        return "Run python3 main.py --init or place the app under config/apps/ (example: config/apps/Sample_App.apk)."
     if "app store" in low or "app_url" in low or "sample_app.json" in low:
         return "Run with --init to set the App Store URL (config/apps/sample_app.json)."
     return ""

--- a/util/enforcement_manager.py
+++ b/util/enforcement_manager.py
@@ -56,7 +56,24 @@ class EnforcementManager:
         return not self.supported_operations or operation in self.supported_operations
 
     def add_supported_operations(self, operations):
-        self.supported_operations = operations
+        normalized = set()
+
+        for op in operations if isinstance(operations, (list, set, tuple)) else ():
+            if isinstance(op, str):
+                op = op.strip()
+                if op:
+                    normalized.add(op)
+            elif isinstance(op, dict):
+                name = (
+                    op.get("operation")
+                    or op.get("name")
+                    or op.get("topic")
+                    or op.get("path")
+                )
+                if isinstance(name, str) and name.strip():
+                    normalized.add(name.strip())
+
+        self.supported_operations = normalized
 
     def get_supported_operations(self):
         return self.supported_operations


### PR DESCRIPTION
Description
This PR resolves an issue where invalid MQTT broker arguments (e.g., including protocol prefixes like mqtt:// or specific port suffixes like :1883) lead to raw, unhandled Python tracebacks (socket.gaierror: [Errno -2] Name or service not known).

To prevent these tracebacks and guide the user toward correct usage, this PR implements modular argument validation and robust defensive connection handling.

Kept main.py clean by importing validate_arguments_and_warn at the top level and executing it immediately after parsing.
Updated the --broker / -b help text in argparse to specify host/IP only (excluding schemes and ports).
Defensive Connection Handling in dab_client.py:

Wrapped the MQTT connect() operation in a try-except block.
Handles socket.gaierror, ConnectionRefusedError, TimeoutError, and general OSError gracefully by delegating output formatting to handle_connection_error(), logging an actionable message, and exiting cleanly with exit code 2 instead of showing raw tracebacks.


fix: skip install payload setup for unsupported tests

- Move DAB version and operation checks before payload resolution.
- Return OPTIONAL_FAILED when device version or operations mismatch.
- Skip missing install artifacts with setup guidance instead.
- Normalize operations/list entries from strings or dictionaries.
- Avoid starting runtime install bridge before support is confirmed.