### PR TITLE
Fix issues patch1

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For local `applications/install` flows, the suite opens a temporary FastAPI brid
 
   The following is command to run Spec conformance Test Suite:
   ```
-  ❯ python3 main.py -v -b <mqtt-broker-ip> -I <dab-device-id> -s "conformance"
+  python3 main.py -v -b <mqtt-broker-ip> -I <dab-device-id> -s conformance
   ```
 
 

--- a/conformance.py
+++ b/conformance.py
@@ -25,7 +25,7 @@ CONFORMANCE_TEST_CASE = [
     ("applications/launch",lambda: f'{{"appId": "{config.apps["youtube"]}", "parameters": ["v%3DSs75O8yllyc","enableEventConsole%3Dtrue","env_showConsole%3Dtrue"]}}', dab.applications.launch, 10000, "with parameters", "2.0", False),
     ("applications/launch",f'{{"appId": "{config.apps["youtube"]}", "parameters_": ["v%3DSs75O8yllyc","enableEventConsole%3Dtrue","env_showConsole%3Dtrue"]}}', dab.applications.launch, 10000, "with parameters bad request 1", "2.0", True),
     ("applications/launch",f'{{"appId": "{config.apps["youtube"]}", "parameters": true}}', dab.applications.launch, 10000, "with parameters bad request 2", "2.0", True),
-    ("applications/launch-with-content",f'{{"appId": "{config.apps["youtube"]}", "contentId": "jfKfPfyJRdk"}}', dab.applications.launch_with_content, 10000, "Conformance", "2.0", False),
+    ("applications/launch-with-content",f'{{"appId": "{config.apps["youtube"]}", "contentId": "CNeakmoER7Q"}}', dab.applications.launch_with_content, 10000, "Conformance", "2.0", False),
     ("applications/launch-with-content",f'{{"appId": "{config.apps["youtube"]}", "contentId": "invalid_id"}}', dab.applications.launch_with_content, 10000, "Conformance invalid content", "2.0", True),
     ("applications/get-state",f'{{"appId": "{config.apps["youtube"]}"}}', dab.applications.get_state, 200, "Conformance", "2.0", False),
     ("applications/exit",f'{{"appId": "{config.apps["youtube"]}"}}', dab.applications.exit, 5000, "Conformance", "2.0", False),


### PR DESCRIPTION
Current Content ID: jfKfPfyJRdk

Proposed Content ID: CNeakmoER7Q

Failure Reason: The DUT is not able to launch the requested content because the video for the specified Content ID is unavailable. Because of this, the applications/launch-with-content conformance test fails even though the launch operation itself may be working correctly.

Expected Behavior: The test should use a valid and available Content ID so that the DUT can launch the content successfully and validate the applications/launch-with-content operation correctly.

Proposed Fix: Update the test configuration by replacing the current Content ID with the new available Content ID.